### PR TITLE
Save scraped records to CSV

### DIFF
--- a/node_server/server.js
+++ b/node_server/server.js
@@ -12,7 +12,7 @@ if (!fs.existsSync(folderName)) {
   fs.mkdirSync(folderName, { recursive: true });
 }
 
-const dataFilePath = path.join(folderName, 'data.txt');
+const dataFilePath = path.join(folderName, 'data.csv');
 
 function normaliseValue(value) {
   if (value == null) {
@@ -26,19 +26,85 @@ function normaliseValue(value) {
   return JSON.stringify(value);
 }
 
-function appendTableToFile(headers, rows) {
+function parseCsvLine(line) {
+  const cells = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      cells.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  cells.push(current);
+
+  return cells;
+}
+
+function loadCsvHeaders(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const [firstLine] = content.split(/\r?\n/, 1);
+
+  if (!firstLine) {
+    return [];
+  }
+
+  return parseCsvLine(firstLine);
+}
+
+function loadCsvRows(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.split(/\r?\n/).filter((line) => line.length > 0);
+
+  if (lines.length <= 1) {
+    return [];
+  }
+
+  return lines.slice(1).map((line) => parseCsvLine(line));
+}
+
+function escapeCsvCell(value) {
+  if (value == null) {
+    return '';
+  }
+
+  const stringValue = String(value);
+  const escaped = stringValue.replace(/"/g, '""');
+
+  return /[",\n]/.test(escaped) ? `"${escaped}"` : escaped;
+}
+
+function writeCsvFile(filePath, headers, rows) {
   if (headers.length === 0) {
     return;
   }
 
-  const headerLine = headers.join('\t');
-  const bodyLines = rows.map((row) => row.join('\t'));
-  const block = [headerLine, ...bodyLines].join('\n');
+  const headerLine = headers.map((header) => escapeCsvCell(header)).join(',');
+  const rowLines = rows.map((row) => row.map((cell) => escapeCsvCell(cell)).join(','));
+  const csvContent = [headerLine, ...rowLines].join('\n');
 
-  const needsLeadingNewline = fs.existsSync(dataFilePath) && fs.statSync(dataFilePath).size > 0;
-  const prefix = needsLeadingNewline ? '\n' : '';
-
-  fs.appendFileSync(dataFilePath, `${prefix}${block}\n`);
+  fs.writeFileSync(filePath, `${csvContent}\n`);
 }
 
 app.post('/scrape_data', (req, res) => {
@@ -62,19 +128,41 @@ app.post('/scrape_data', (req, res) => {
     if (payloadArray.length === 0) {
       console.warn('No structured data received to persist.');
     } else {
-      const allHeaders = new Set();
+      const existingHeaders = loadCsvHeaders(dataFilePath);
+      const existingRows = loadCsvRows(dataFilePath);
+
+      const headers = Array.isArray(existingHeaders) && existingHeaders.length > 0
+        ? [...existingHeaders]
+        : [];
+
+      const headerSet = new Set(headers);
+
       payloadArray.forEach((entry) => {
         if (entry && typeof entry === 'object') {
-          Object.keys(entry).forEach((key) => allHeaders.add(key));
+          Object.keys(entry).forEach((key) => {
+            if (!headerSet.has(key)) {
+              headerSet.add(key);
+              headers.push(key);
+            }
+          });
         }
       });
 
-      const headers = Array.from(allHeaders);
-      const rows = payloadArray.map((entry) => {
-        return headers.map((key) => normaliseValue(entry?.[key]));
+      const reconciledExistingRows = existingRows.map((row) => {
+        const rowMap = {};
+
+        (existingHeaders || []).forEach((header, index) => {
+          rowMap[header] = row[index] ?? '';
+        });
+
+        return headers.map((header) => rowMap[header] ?? '');
       });
 
-      appendTableToFile(headers, rows);
+      const newRows = payloadArray.map((entry) => {
+        return headers.map((header) => normaliseValue(entry?.[header]));
+      });
+
+      writeCsvFile(dataFilePath, headers, [...reconciledExistingRows, ...newRows]);
     }
 
     const baseId = !Array.isArray(parsedData) && parsedData?.id ? parsedData.id : `data_${Date.now()}`;


### PR DESCRIPTION
## Summary
- persist scraped payloads into `jsons/data.csv` instead of the previous text file
- ensure CSV headers remain consistent and append new columns when unseen fields arrive
- keep saving the full JSON payload alongside the CSV export

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da78a1ec3c832b8dc02c7832c95332