### PR TITLE
Ensure scraped images are saved as PNGs named by record id

### DIFF
--- a/driver_server/background.js
+++ b/driver_server/background.js
@@ -470,6 +470,7 @@ async function contentScriptFunction(item) {
       return {
         dataUrl: pngDataUrl,
         fileName: baseFileName,
+        extension: "png",
         sourceUrl: absoluteUrl,
         contentType: "image/png",
       };

--- a/node_server/server.js
+++ b/node_server/server.js
@@ -198,14 +198,29 @@ function saveImageValue(value, baseId, entryIndex, fieldKey) {
 
   const buffer = Buffer.from(base64Payload, 'base64');
 
-  const preferredName =
-    typeof value.fileName === 'string' && value.fileName.trim()
+  const preferredName = (() => {
+    const fromValue = typeof value.fileName === 'string' && value.fileName.trim()
       ? value.fileName.trim()
       : typeof value.name === 'string' && value.name.trim()
         ? value.name.trim()
-        : `${baseId}-${entryIndex}-${fieldKey}`;
+        : null;
 
-  const extension = determineImageExtension(value.contentType || mimeType, value.sourceUrl);
+    if (fromValue) {
+      return fromValue;
+    }
+
+    if (typeof baseId === 'string' || typeof baseId === 'number') {
+      return String(baseId);
+    }
+
+    return `${entryIndex}-${fieldKey}`;
+  })();
+
+  const extensionPreference = typeof value.extension === 'string' && value.extension.trim()
+    ? value.extension.trim().toLowerCase()
+    : null;
+
+  const extension = extensionPreference || determineImageExtension(value.contentType || mimeType, value.sourceUrl);
   const filePath = generateUniqueImagePath(preferredName, extension);
 
   fs.writeFileSync(filePath, buffer);


### PR DESCRIPTION
## Summary
- tag scraped image results with an explicit PNG extension so they are treated as converted PNGs
- honour the provided filename and extension when writing images on the server, falling back to the record id

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2967bc0e4832ba0feb24e4840fc5f