### PR TITLE
Save scraped data directly from extension

### DIFF
--- a/driver_server/background.js
+++ b/driver_server/background.js
@@ -141,7 +141,7 @@ function openAndScrape(item) {
                 throw new Error("Scraped data is null or undefined.");
               }
 
-              await sendDataToServer(result);
+              await saveScrapedDataLocally(result);
 
               const waiter = Array.isArray(item.requests)
                 ? item.requests.find(
@@ -842,26 +842,417 @@ function waitMs(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/************************************************
- * Send data to local server
- ************************************************/
-async function sendDataToServer(scrapedData) {
-  const bodyObj = {
-    l_scraped_data: JSON.stringify(scrapedData),
-  };
-
-  const resp = await fetch("http://localhost:3021/scrape_data", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(bodyObj),
+function storageGet(keys) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(keys, (items) => {
+      if (chrome.runtime.lastError) {
+        return reject(chrome.runtime.lastError);
+      }
+      resolve(items || {});
+    });
   });
+}
 
-  if (!resp.ok) {
-    throw new Error(`Server responded with ${resp.status}`);
+function storageSet(items) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set(items, () => {
+      if (chrome.runtime.lastError) {
+        return reject(chrome.runtime.lastError);
+      }
+      resolve();
+    });
+  });
+}
+
+function normaliseValue(value) {
+  if (value == null) {
+    return "";
   }
 
-  const respJson = await resp.json();
-  console.log("Local server response:", respJson);
+  if (typeof value === "string") {
+    return value.replace(/\s+/g, " ").trim();
+  }
+
+  return JSON.stringify(value);
+}
+
+function escapeCsvCell(value) {
+  if (value == null) {
+    return "";
+  }
+
+  const stringValue = String(value);
+  const escaped = stringValue.replace(/"/g, '""');
+
+  return /[",\n]/.test(escaped) ? `"${escaped}"` : escaped;
+}
+
+function writeCsvContent(headers, rows) {
+  if (!headers.length) {
+    return "";
+  }
+
+  const headerLine = headers.map((header) => escapeCsvCell(header)).join(",");
+  const rowLines = rows.map((row) => row.map((cell) => escapeCsvCell(cell)).join(","));
+  return [headerLine, ...rowLines].join("\n") + "\n";
+}
+
+function sanitizeFileNameSegment(segment) {
+  if (!segment) {
+    return "";
+  }
+
+  return segment.replace(/[\\/:*?"<>|\s]+/g, "_");
+}
+
+function ensureImageExtension(fileName, extension) {
+  if (!extension) {
+    return sanitizeFileNameSegment(fileName);
+  }
+
+  const sanitized = sanitizeFileNameSegment(fileName);
+  if (new RegExp(`\\.${extension}$`, "i").test(sanitized)) {
+    return sanitized;
+  }
+
+  return `${sanitized}.${extension}`;
+}
+
+function determineImageExtension(contentType, sourceUrl) {
+  if (contentType) {
+    const mime = contentType.split(";")[0].trim().toLowerCase();
+    const mimeMap = {
+      "image/jpeg": "jpg",
+      "image/jpg": "jpg",
+      "image/png": "png",
+      "image/gif": "gif",
+      "image/webp": "webp",
+      "image/svg+xml": "svg",
+      "image/bmp": "bmp",
+      "image/x-icon": "ico",
+      "image/vnd.microsoft.icon": "ico",
+    };
+
+    if (mimeMap[mime]) {
+      return mimeMap[mime];
+    }
+  }
+
+  if (sourceUrl) {
+    const match = sourceUrl.match(/\.([a-z0-9]+)(?:[?#].*)?$/i);
+    if (match) {
+      return match[1].toLowerCase();
+    }
+  }
+
+  return "png";
+}
+
+function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function isImageDescriptor(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof value.type === "string" &&
+    value.type.trim().toLowerCase() === "img"
+  );
+}
+
+function isDirectImagePayload(value) {
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every((entry) => isDirectImagePayload(entry));
+  }
+
+  return isImageDescriptor(value);
+}
+
+async function getImageNameRegistry() {
+  const { imageNames } = await storageGet(["imageNames"]);
+  return new Set(Array.isArray(imageNames) ? imageNames : []);
+}
+
+async function storeImageNameRegistry(registry) {
+  await storageSet({ imageNames: Array.from(registry) });
+}
+
+async function reserveImageName(baseName, extension) {
+  const registry = await getImageNameRegistry();
+  const base = sanitizeFileNameSegment(baseName) || "image";
+  let candidate = ensureImageExtension(base, extension);
+  let counter = 1;
+
+  while (registry.has(candidate)) {
+    candidate = ensureImageExtension(`${base}-${counter}`, extension);
+    counter += 1;
+  }
+
+  registry.add(candidate);
+  await storeImageNameRegistry(registry);
+  return candidate;
+}
+
+async function downloadFile({ url, filename, mimeType }) {
+  const downloadUrl = mimeType
+    ? `data:${mimeType};charset=utf-8,${encodeURIComponent(url)}`
+    : url;
+
+  return new Promise((resolve, reject) => {
+    chrome.downloads.download(
+      {
+        url: downloadUrl,
+        filename,
+        conflictAction: "overwrite",
+        saveAs: false,
+      },
+      (downloadId) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        resolve(downloadId);
+      }
+    );
+  });
+}
+
+async function saveImageValue(value, baseId, entryIndex, fieldKey) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const typeHint = typeof value.type === "string" ? value.type.trim().toLowerCase() : null;
+
+  if (typeHint !== "img") {
+    return null;
+  }
+
+  const preferredName = (() => {
+    const fromValue = typeof value.fileName === "string" && value.fileName.trim()
+      ? value.fileName.trim()
+      : typeof value.name === "string" && value.name.trim()
+        ? value.name.trim()
+        : null;
+
+    if (fromValue) {
+      return fromValue;
+    }
+
+    if (typeof baseId === "string" || typeof baseId === "number") {
+      return String(baseId);
+    }
+
+    const keySegment = fieldKey ? `-${fieldKey}` : "";
+    return `${entryIndex}${keySegment}`;
+  })();
+
+  const extensionPreference = typeof value.extension === "string" && value.extension.trim()
+    ? value.extension.trim().toLowerCase()
+    : null;
+
+  const dataUrl = typeof value.dataUrl === "string" ? value.dataUrl : null;
+  const directUrl = typeof value.sourceUrl === "string" && value.sourceUrl.trim()
+    ? value.sourceUrl.trim()
+    : null;
+
+  if (dataUrl && dataUrl.startsWith("data:")) {
+    const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
+    if (!match) {
+      return null;
+    }
+
+    const [, mimeType, base64Payload] = match;
+    if (!base64Payload) {
+      return null;
+    }
+
+    const extension = extensionPreference || determineImageExtension(value.contentType || mimeType, value.sourceUrl);
+    const candidateName = await reserveImageName(preferredName, extension);
+
+    await downloadFile({
+      url: dataUrl,
+      filename: `images/${candidateName}`,
+    });
+
+    return `images/${candidateName}`;
+  }
+
+  if (directUrl) {
+    const extension = extensionPreference || determineImageExtension(value.contentType, directUrl);
+    const candidateName = await reserveImageName(preferredName, extension);
+
+    await downloadFile({
+      url: directUrl,
+      filename: `images/${candidateName}`,
+    });
+
+    return `images/${candidateName}`;
+  }
+
+  return null;
+}
+
+async function processImageValue(value, baseId, entryIndex, fieldPath) {
+  const savedPath = await saveImageValue(value, baseId, entryIndex, fieldPath);
+  if (savedPath) {
+    return savedPath;
+  }
+
+  if (Array.isArray(value)) {
+    const results = [];
+    for (let idx = 0; idx < value.length; idx += 1) {
+      const nextPath = fieldPath ? `${fieldPath}-${idx}` : String(idx);
+      results.push(await processImageValue(value[idx], baseId, entryIndex, nextPath));
+    }
+    return results;
+  }
+
+  if (value && typeof value === "object" && isPlainObject(value)) {
+    const entries = {};
+    const keys = Object.keys(value);
+    for (const key of keys) {
+      const nextPath = fieldPath ? `${fieldPath}.${key}` : key;
+      entries[key] = await processImageValue(value[key], baseId, entryIndex, nextPath);
+    }
+    return entries;
+  }
+
+  return value;
+}
+
+async function processEntryImages(entry, baseId, entryIndex) {
+  return processImageValue(entry, baseId, entryIndex, "");
+}
+
+async function saveScrapedDataLocally(scrapedData) {
+  const originalPayload = scrapedData;
+  let parsedData = scrapedData;
+
+  const baseId = !Array.isArray(parsedData) && parsedData?.id
+    ? parsedData.id
+    : `data_${Date.now()}`;
+
+  if (isDirectImagePayload(originalPayload)) {
+    if (Array.isArray(parsedData)) {
+      for (let index = 0; index < parsedData.length; index += 1) {
+        await processImageValue(parsedData[index], baseId, index, "");
+      }
+    } else {
+      await processImageValue(parsedData, baseId, "image", "");
+    }
+
+    console.log("Image payload received. Skipped JSON and CSV persistence.");
+    return;
+  }
+
+  let payloadArray = [];
+  let baseMetadata = {};
+
+  if (Array.isArray(parsedData)) {
+    const processedArray = [];
+    for (let index = 0; index < parsedData.length; index += 1) {
+      processedArray.push(await processEntryImages(parsedData[index], baseId, index));
+    }
+    parsedData = processedArray;
+
+    payloadArray = processedArray.map((entry) => {
+      if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+        return { ...entry };
+      }
+
+      return { value: normaliseValue(entry) };
+    });
+  } else if (parsedData && typeof parsedData === "object") {
+    const { data, ...rest } = parsedData;
+    baseMetadata = await processEntryImages(rest, baseId, "meta");
+
+    if (Array.isArray(data)) {
+      const processedDataArray = [];
+      for (let index = 0; index < data.length; index += 1) {
+        processedDataArray.push(await processEntryImages(data[index], baseId, index));
+      }
+      parsedData = { ...baseMetadata, data: processedDataArray };
+
+      payloadArray = processedDataArray.map((entry) => {
+        if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+          return { ...baseMetadata, ...entry };
+        }
+
+        return { ...baseMetadata, value: normaliseValue(entry) };
+      });
+    } else if (data !== undefined) {
+      const processedDataValue = await processEntryImages(data, baseId, "data");
+      parsedData = { ...baseMetadata, data: processedDataValue };
+
+      if (Object.keys(baseMetadata).length > 0) {
+        payloadArray = [{ ...baseMetadata }];
+      }
+    } else {
+      parsedData = { ...baseMetadata };
+      if (Object.keys(baseMetadata).length > 0) {
+        payloadArray = [{ ...baseMetadata }];
+      }
+    }
+  }
+
+  if (payloadArray.length === 0) {
+    console.warn("No structured data received to persist.");
+  } else {
+    const { csvHeaders, csvRows } = await storageGet(["csvHeaders", "csvRows"]);
+    const existingHeaders = Array.isArray(csvHeaders) ? csvHeaders : [];
+    const existingRows = Array.isArray(csvRows) ? csvRows : [];
+
+    const headers = existingHeaders.length > 0 ? [...existingHeaders] : [];
+    const headerSet = new Set(headers);
+
+    payloadArray.forEach((entry) => {
+      if (entry && typeof entry === "object") {
+        Object.keys(entry).forEach((key) => {
+          if (!headerSet.has(key)) {
+            headerSet.add(key);
+            headers.push(key);
+          }
+        });
+      }
+    });
+
+    const reconciledExistingRows = existingRows.map((row) => {
+      const rowMap = {};
+
+      existingHeaders.forEach((header, index) => {
+        rowMap[header] = row[index] ?? "";
+      });
+
+      return headers.map((header) => rowMap[header] ?? "");
+    });
+
+    const newRows = payloadArray.map((entry) => {
+      return headers.map((header) => normaliseValue(entry?.[header]));
+    });
+
+    const updatedRows = [...reconciledExistingRows, ...newRows];
+    await storageSet({ csvHeaders: headers, csvRows: updatedRows });
+
+    const csvContent = writeCsvContent(headers, updatedRows);
+    if (csvContent) {
+      await downloadFile({
+        url: csvContent,
+        filename: "jsons/data.csv",
+        mimeType: "text/csv",
+      });
+    }
+  }
+
+  const jsonContent = JSON.stringify(parsedData, null, 2);
+  const fileName = `${baseId}.json`;
+
+  await downloadFile({
+    url: jsonContent,
+    filename: `jsons/${fileName}`,
+    mimeType: "application/json",
+  });
+
+  console.log(`Saved data to ${fileName}`);
 }

--- a/driver_server/manifest.json
+++ b/driver_server/manifest.json
@@ -6,7 +6,9 @@
   "permissions": [
     "tabs",
     "scripting",
-    "activeTab"
+    "activeTab",
+    "downloads",
+    "storage"
   ],
   "host_permissions": [
     "https://brilliantcontract.net:8443/*",


### PR DESCRIPTION
### Motivation
- Stop posting scraped results to the external `node_server` and persist them directly from the extension to avoid reliance on the local server.
- Mirror the server-side persistence format (CSV, JSON and image handling) so saved files remain compatible with existing workflows.

### Description
- Replaced the network call `sendDataToServer` with a local implementation `saveScrapedDataLocally` and updated call sites to use it.
- Implemented local persistence utilities using `chrome.storage.local` (`storageGet`/`storageSet`) to keep CSV headers/rows and an image name registry, and `downloadFile` (via `chrome.downloads.download`) to write `jsons/*.json`, `jsons/data.csv` and `images/*` files.
- Ported server-side logic for CSV generation (`normaliseValue`, `escapeCsvCell`, `writeCsvContent`), image detection/processing (`isImageDescriptor`, `isDirectImagePayload`, `processImageValue`, `saveImageValue`) and filename sanitisation so image and JSON payloads are handled equivalently to `node_server/server.js`.
- Updated `manifest.json` to add `downloads` and `storage` permissions required for local saving.

### Testing
- No automated tests were run for this change (no CI/test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967b9df755c832b9ae240fbf71e544a)