### PR TITLE
Tighten selector normalization to avoid rewriting :has-text patterns

### DIFF
--- a/driver_server/background.js
+++ b/driver_server/background.js
@@ -360,7 +360,7 @@ async function contentScriptFunction(item) {
     }
 
     return segment.replace(
-      /(^|[^:])(\b[a-zA-Z][a-zA-Z0-9_-]*|\*)\((['"])(.*?)\3\)/g,
+      /(^|[^:\w-])(\b[a-zA-Z][a-zA-Z0-9_-]*|\*)\((['"])(.*?)\3\)/g,
       (match, prefix, tagName, quote, text) =>
         `${prefix}${tagName}:has-text(${quote}${text}${quote})`
     );


### PR DESCRIPTION
### Motivation
- The selector normalizer was overly permissive when converting function-like `tag('text')` syntax into `:has-text('text')`, which could rewrite or break existing `:has-text()` segments and other contexts.

### Description
- Update the regex in `normalizeSelectorSegment` inside `driver_server/background.js` to use `/(^|[^:\w-])(...)/g` instead of `/(^|[^:])(...)/g`, tightening the prefix check so existing `:has-text()` and adjacent identifier characters are not matched and rewritten.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a5da902f4832b9e5b70b2bc0ba031)